### PR TITLE
register node type

### DIFF
--- a/src/__tests__/processor_register.js
+++ b/src/__tests__/processor_register.js
@@ -1,0 +1,18 @@
+import test from 'ava'
+import { register } from '../processor'
+
+// This registers group into the processor.
+import '../node_types/group'
+
+function processorError(t, errorRegex, node) {
+    t.throws(() => register(node), errorRegex)
+}
+processorError.title = (providedTitle, regex) => `error: ${regex}`
+
+const TYPE = 'RegistrationTest'
+test(processorError, /missing TYPE/, {})
+test(processorError, /missing factory/, { TYPE })
+test(processorError, /missing nodeProcessor/, { TYPE, factory() {} })
+
+// group already exists:
+test(processorError, /already registered/, { TYPE: 'group', factory() {}, nodeProcessor() {} })

--- a/src/actions-reducer.js
+++ b/src/actions-reducer.js
@@ -5,7 +5,7 @@ export const setActionStatusDone = (id) => ({
     payload: id,
 })
 
-export const selectIsReady = (state, id) => state.fetchTree && state.fetchTree[id] != null
+export const selectIsReady = (state, id) => Boolean(state.fetchTree && state.fetchTree[id] != null)
 
 export default function reducer(state = {}, action) {
     if (action.type !== ACTION_DONE) return state

--- a/src/index.js
+++ b/src/index.js
@@ -10,6 +10,9 @@ import lazy from './node_types/lazy'
 import component from './component'
 import reducer from './actions-reducer'
 
+import { register as registerNodeType } from './processor.js'
+
 export { group, loader, selector, depends, preload, reducer, debug, virtual, lazy }
 
+export { registerNodeType }
 export default component

--- a/src/node_types/__tests__/debug.js
+++ b/src/node_types/__tests__/debug.js
@@ -1,0 +1,28 @@
+import test from 'ava'
+import debug from '../debug'
+
+test(`debug.processor sets debug in the context and processes its child`, t => {
+    const childNode = { TYPE: 'example' }
+    const node = debug(childNode)
+
+    const context = {
+        someNonsenseValue: {},
+        debug: false,
+    }
+
+    const next = (childContext, node) => {
+        // The node sets debug in the context
+        t.is(childContext.debug, true)
+        // This is a NEW context, not modified
+        t.not(childContext, context)
+        // The new context inherits the existing properties
+        t.is(childContext.someNonsenseValue, context.someNonsenseValue)
+        // the child node is processed unmodified
+        t.is(node, childNode)
+    }
+
+    debug.nodeProcessor(next, context, node)
+
+    // Original context was not modified
+    t.is(context.debug, false)
+})

--- a/src/node_types/__tests__/loader.js
+++ b/src/node_types/__tests__/loader.js
@@ -1,4 +1,5 @@
 import test from 'ava'
+import td from 'testdouble'
 import loader from '../loader'
 
 test(`loader without an action`, t => {
@@ -46,3 +47,46 @@ test(`loader return type`, t => {
 
     t.deepEqual(actual, expected)
 })
+
+function processorMacro(t, state, expected) {
+    const todoId = 1
+
+    const nodeDefinition = {
+        id: (id) => `key-${id}`,
+        action: td.function('.action'),
+        selector: td.function('.selector'),
+    }
+    td.when(nodeDefinition.selector(state, todoId)).thenReturn('someValue')
+
+    const node = loader(nodeDefinition)
+    const next = () => undefined
+
+    const processorContext = {
+        state,
+        queue: td.function('.queue'),
+    }
+
+    const actual = loader.nodeProcessor(next, processorContext, node, todoId)
+
+    td.verify(processorContext.queue('key-1', nodeDefinition.action, [todoId]))
+    t.deepEqual(actual, expected)
+}
+
+
+test(
+    'macro (not ready)',
+    processorMacro,
+    {},
+    { isReady: false, value: undefined }
+)
+
+test(
+    'macro (ready)',
+    processorMacro,
+    {
+        fetchTree: {
+            'key-1': true,
+        },
+    },
+    { isReady: true, value: 'someValue' }
+)

--- a/src/node_types/__tests__/loader.js
+++ b/src/node_types/__tests__/loader.js
@@ -61,14 +61,14 @@ function processorMacro(t, state, expected) {
     const node = loader(nodeDefinition)
     const next = () => undefined
 
-    const processorContext = {
+    const scope = {
         state,
         queue: td.function('.queue'),
     }
 
-    const actual = loader.nodeProcessor(next, processorContext, node, todoId)
+    const actual = loader.nodeProcessor(next, scope, node, todoId)
 
-    td.verify(processorContext.queue('key-1', nodeDefinition.action, [todoId]))
+    td.verify(scope.queue('key-1', nodeDefinition.action, [todoId]))
     t.deepEqual(actual, expected)
 }
 

--- a/src/node_types/__tests__/virtual.js
+++ b/src/node_types/__tests__/virtual.js
@@ -1,0 +1,21 @@
+import test from 'ava'
+import virtual from '../virtual'
+import processor from '../../processor'
+
+test(`virtual throws if you don't supply a child node`, t => {
+    t.throws(() => virtual(), /Missing child/)
+})
+
+test(`virtual adds excludeProp to the return value`, t => {
+    const state = { foo: 'fooState' }
+    const props = {}
+
+    const node = virtual(
+        (state) => state.foo
+    )
+
+    const actual = processor(node, state, props)
+
+    t.is(actual.value, 'fooState')
+    t.true(actual.excludeProp)
+})

--- a/src/node_types/debug.js
+++ b/src/node_types/debug.js
@@ -13,15 +13,15 @@ export default function debug(child) {
 }
 
 /* eslint-disable no-console */
-register(TYPE, (next, context, node, state) => {
-    const childContext = {
-        ...context,
+register(TYPE, (next, processingContext, node, state) => {
+    const childProcessingContext = {
+        ...processingContext,
         debug: true,
     }
 
     try {
         console.groupCollapsed('DEBUG')
-        return next(childContext, node.child, state)
+        return next(childProcessingContext, node.child, state)
     } finally {
         console.groupEnd('DEBUG')
     }

--- a/src/node_types/debug.js
+++ b/src/node_types/debug.js
@@ -13,7 +13,7 @@ export default function debug(child) {
 }
 
 /* eslint-disable no-console */
-register(TYPE, (next, processingContext, node, state) => {
+register(TYPE, (next, processingContext, node) => {
     const childProcessingContext = {
         ...processingContext,
         debug: true,
@@ -21,7 +21,7 @@ register(TYPE, (next, processingContext, node, state) => {
 
     try {
         console.groupCollapsed('DEBUG')
-        return next(childProcessingContext, node.child, state)
+        return next(childProcessingContext, node.child)
     } finally {
         console.groupEnd('DEBUG')
     }

--- a/src/node_types/debug.js
+++ b/src/node_types/debug.js
@@ -13,7 +13,7 @@ export default function debug(child) {
 }
 
 /* eslint-disable no-console */
-register(TYPE, (next, context, node, state, props) => {
+register(TYPE, (next, context, node, state) => {
     const childContext = {
         ...context,
         debug: true,
@@ -21,7 +21,7 @@ register(TYPE, (next, context, node, state, props) => {
 
     try {
         console.groupCollapsed('DEBUG')
-        return next(childContext, node.child, state, props)
+        return next(childContext, node.child, state)
     } finally {
         console.groupEnd('DEBUG')
     }

--- a/src/node_types/debug.js
+++ b/src/node_types/debug.js
@@ -27,15 +27,15 @@ export default register({
             child,
         }
     },
-    nodeProcessor(next, processingContext, node) {
-        const childProcessingContext = {
-            ...processingContext,
+    nodeProcessor(next, scope, node) {
+        const childScope = {
+            ...scope,
             debug: true,
         }
 
         try {
             groupCollapsed('DEBUG')
-            return next(childProcessingContext, node.child)
+            return next(childScope, node.child)
         } finally {
             groupEnd('DEBUG')
         }

--- a/src/node_types/debug.js
+++ b/src/node_types/debug.js
@@ -1,29 +1,43 @@
 import { register } from '../processor'
 const TYPE = 'debug'
 
-export default function debug(child) {
-    if (child == null) {
-        throw new Error('Missing child')
-    }
-
-    return {
-        TYPE,
-        child,
-    }
-}
 
 /* eslint-disable no-console */
-register(TYPE, (next, processingContext, node) => {
-    const childProcessingContext = {
-        ...processingContext,
-        debug: true,
-    }
-
-    try {
-        console.groupCollapsed('DEBUG')
-        return next(childProcessingContext, node.child)
-    } finally {
-        console.groupEnd('DEBUG')
+const groupCollapsed = (...args) => {
+    if (console.groupCollapsed != null) {
+        console.groupCollapsed(...args)
     }
 }
-)
+const groupEnd = (...args) => {
+    if (console.groupEnd != null) {
+        console.groupEnd(...args)
+    }
+}
+
+
+export default register({
+    TYPE,
+    factory(child) {
+        if (child == null) {
+            throw new Error('Missing child')
+        }
+
+        return {
+            TYPE,
+            child,
+        }
+    },
+    nodeProcessor(next, processingContext, node) {
+        const childProcessingContext = {
+            ...processingContext,
+            debug: true,
+        }
+
+        try {
+            groupCollapsed('DEBUG')
+            return next(childProcessingContext, node.child)
+        } finally {
+            groupEnd('DEBUG')
+        }
+    },
+})

--- a/src/node_types/debug.js
+++ b/src/node_types/debug.js
@@ -1,3 +1,4 @@
+import { register } from '../processor'
 const TYPE = 'debug'
 
 export default function debug(child) {
@@ -10,4 +11,19 @@ export default function debug(child) {
         child,
     }
 }
-debug.TYPE = TYPE
+
+/* eslint-disable no-console */
+register(TYPE, (next, context, node, state, props) => {
+    const childContext = {
+        ...context,
+        debug: true,
+    }
+
+    try {
+        console.groupCollapsed('DEBUG')
+        return next(childContext, node.child, state, props)
+    } finally {
+        console.groupEnd('DEBUG')
+    }
+}
+)

--- a/src/node_types/depends.js
+++ b/src/node_types/depends.js
@@ -53,10 +53,10 @@ depends.value = value
 
 depends.TYPE = TYPE
 
-register(TYPE, (next, context, node, state) => {
+register(TYPE, (next, processingContext, node, state) => {
     let isReady = true
 
-    if (context.debug) {
+    if (processingContext.debug) {
         console.log('node.dependencies: ', ...node.dependencies)
     }
 
@@ -70,10 +70,10 @@ register(TYPE, (next, context, node, state) => {
         const path = dep.path.split('.')
         let root
         if (dep.type === 'prop') {
-            root = context.props
+            root = processingContext.props
         } else if (dep.type === 'resource') {
             const key = path.shift()
-            const resource = context.resources[key]
+            const resource = processingContext.resources[key]
 
             if (resource.isReady) {
                 root = resource.value
@@ -95,5 +95,5 @@ register(TYPE, (next, context, node, state) => {
         }
     }
 
-    return next(context, node.child, state, ...args)
+    return next(processingContext, node.child, state, ...args)
 })

--- a/src/node_types/depends.js
+++ b/src/node_types/depends.js
@@ -53,7 +53,7 @@ depends.value = value
 
 depends.TYPE = TYPE
 
-register(TYPE, (next, processingContext, node, state) => {
+register(TYPE, (next, processingContext, node) => {
     let isReady = true
 
     if (processingContext.debug) {
@@ -95,5 +95,5 @@ register(TYPE, (next, processingContext, node, state) => {
         }
     }
 
-    return next(processingContext, node.child, state, ...args)
+    return next(processingContext, node.child, ...args)
 })

--- a/src/node_types/depends.js
+++ b/src/node_types/depends.js
@@ -48,10 +48,10 @@ const depends = register({
             child,
         }
     },
-    nodeProcessor(next, processingContext, node) {
+    nodeProcessor(next, scope, node) {
         let isReady = true
 
-        if (processingContext.debug) {
+        if (scope.debug) {
             console.log('node.dependencies: ', ...node.dependencies)
         }
 
@@ -65,10 +65,10 @@ const depends = register({
             const path = dep.path.split('.')
             let root
             if (dep.type === 'prop') {
-                root = processingContext.props
+                root = scope.props
             } else if (dep.type === 'resource') {
                 const key = path.shift()
-                const resource = processingContext.resources[key]
+                const resource = scope.resources[key]
 
                 if (resource.isReady) {
                     root = resource.value
@@ -90,14 +90,12 @@ const depends = register({
             }
         }
 
-        return next(processingContext, node.child, ...args)
+        return next(scope, node.child, ...args)
     },
 })
 
 depends.prop = prop
 depends.resource = resource
 depends.value = value
-
-depends.TYPE = TYPE
 
 export default depends

--- a/src/node_types/depends.js
+++ b/src/node_types/depends.js
@@ -53,7 +53,7 @@ depends.value = value
 
 depends.TYPE = TYPE
 
-register(TYPE, (next, context, node, state, props) => {
+register(TYPE, (next, context, node, state) => {
     let isReady = true
 
     if (context.debug) {
@@ -70,7 +70,7 @@ register(TYPE, (next, context, node, state, props) => {
         const path = dep.path.split('.')
         let root
         if (dep.type === 'prop') {
-            root = props
+            root = context.props
         } else if (dep.type === 'resource') {
             const key = path.shift()
             const resource = context.resources[key]
@@ -95,5 +95,5 @@ register(TYPE, (next, context, node, state, props) => {
         }
     }
 
-    return next(context, node.child, state, props, ...args)
+    return next(context, node.child, state, ...args)
 })

--- a/src/node_types/group.js
+++ b/src/node_types/group.js
@@ -5,64 +5,66 @@ import { map, reduce } from '../utils'
 
 const TYPE = 'group'
 
-export default function group(children) {
-    if (children == null) {
-        throw new Error('Missing children')
-    }
-    if (Array.isArray(children)) {
-        if (children.length === 0) {
-            throw new Error('Empty children') // Are you my mummy?
+const group = register({
+    TYPE,
+    factory(children) {
+        if (children == null) {
+            throw new Error('Missing children')
         }
-    } else {
-        if (Object.keys(children).length === 0) {
-            throw new Error('Empty children') // Are you my mummy?
+        if (Array.isArray(children)) {
+            if (children.length === 0) {
+                throw new Error('Empty children') // Are you my mummy?
+            }
+        } else {
+            if (Object.keys(children).length === 0) {
+                throw new Error('Empty children') // Are you my mummy?
+            }
         }
-    }
 
-    return {
-        TYPE,
-        children: map(children, normalize),
-    }
-}
-group.TYPE = TYPE
+        return {
+            TYPE,
+            children: map(children, normalize),
+        }
+    },
+    nodeProcessor(next, processingContext, node) {
+        const resources = {}
+        const { path } = processingContext
+
+        const results = reduce(
+            node.children,
+            (x, child, key) => {
+                const childProcessingContext = {
+                    ...processingContext,
+                    resources,
+                    path: [...path, key],
+                }
+                const result = resources[key] = next(childProcessingContext, child)
+                const { isReady, value, excludeProp } = result
+
+                if (excludeProp === true || !isReady) {
+                    return {
+                        ...x,
+                        isReady: x.isReady && isReady,
+                    }
+                }
+
+                const nextValue = Array.isArray(node.children) ?
+                [...x.value, value] :
+                { ...x.value, [key]: value }
+
+                return {
+                    isReady: x.isReady && isReady,
+                    value: nextValue,
+                }
+            },
+            { isReady: true, value: Array.isArray(node.children) ? [] : {} }
+        )
+
+        return results
+    },
+})
 
 group.debug = function debugGroup(children) {
     return debug(group(children))
 }
-
-register(TYPE, (next, processingContext, node) => {
-    const resources = {}
-    const { path } = processingContext
-
-    const results = reduce(
-        node.children,
-        (x, child, key) => {
-            const childProcessingContext = {
-                ...processingContext,
-                resources,
-                path: [...path, key],
-            }
-            const result = resources[key] = next(childProcessingContext, child)
-            const { isReady, value, excludeProp } = result
-
-            if (excludeProp === true || !isReady) {
-                return {
-                    ...x,
-                    isReady: x.isReady && isReady,
-                }
-            }
-
-            const nextValue = Array.isArray(node.children) ?
-            [...x.value, value] :
-            { ...x.value, [key]: value }
-
-            return {
-                isReady: x.isReady && isReady,
-                value: nextValue,
-            }
-        },
-        { isReady: true, value: Array.isArray(node.children) ? [] : {} }
-    )
-
-    return results
-})
+export default group

--- a/src/node_types/group.js
+++ b/src/node_types/group.js
@@ -30,7 +30,7 @@ group.debug = function debugGroup(children) {
     return debug(group(children))
 }
 
-register(TYPE, (next, processingContext, node, state) => {
+register(TYPE, (next, processingContext, node) => {
     const resources = {}
     const { path } = processingContext
 
@@ -42,7 +42,7 @@ register(TYPE, (next, processingContext, node, state) => {
                 resources,
                 path: [...path, key],
             }
-            const result = resources[key] = next(childProcessingContext, child, state)
+            const result = resources[key] = next(childProcessingContext, child)
             const { isReady, value, excludeProp } = result
 
             if (excludeProp === true || !isReady) {

--- a/src/node_types/group.js
+++ b/src/node_types/group.js
@@ -30,19 +30,19 @@ group.debug = function debugGroup(children) {
     return debug(group(children))
 }
 
-register(TYPE, (next, context, node, state) => {
+register(TYPE, (next, processingContext, node, state) => {
     const resources = {}
-    const { path } = context
+    const { path } = processingContext
 
     const results = reduce(
         node.children,
         (x, child, key) => {
-            const childContext = {
-                ...context,
+            const childProcessingContext = {
+                ...processingContext,
                 resources,
                 path: [...path, key],
             }
-            const result = resources[key] = next(childContext, child, state)
+            const result = resources[key] = next(childProcessingContext, child, state)
             const { isReady, value, excludeProp } = result
 
             if (excludeProp === true || !isReady) {

--- a/src/node_types/group.js
+++ b/src/node_types/group.js
@@ -26,19 +26,19 @@ const group = register({
             children: map(children, normalize),
         }
     },
-    nodeProcessor(next, processingContext, node) {
+    nodeProcessor(next, scope, node) {
         const resources = {}
-        const { path } = processingContext
+        const { path } = scope
 
         const results = reduce(
             node.children,
             (x, child, key) => {
-                const childProcessingContext = {
-                    ...processingContext,
+                const childScope = {
+                    ...scope,
                     resources,
                     path: [...path, key],
                 }
-                const result = resources[key] = next(childProcessingContext, child)
+                const result = resources[key] = next(childScope, child)
                 const { isReady, value, excludeProp } = result
 
                 if (excludeProp === true || !isReady) {

--- a/src/node_types/group.js
+++ b/src/node_types/group.js
@@ -30,7 +30,7 @@ group.debug = function debugGroup(children) {
     return debug(group(children))
 }
 
-register(TYPE, (next, context, node, state, props) => {
+register(TYPE, (next, context, node, state) => {
     const resources = {}
     const { path } = context
 
@@ -42,7 +42,7 @@ register(TYPE, (next, context, node, state, props) => {
                 resources,
                 path: [...path, key],
             }
-            const result = resources[key] = next(childContext, child, state, props)
+            const result = resources[key] = next(childContext, child, state)
             const { isReady, value, excludeProp } = result
 
             if (excludeProp === true || !isReady) {

--- a/src/node_types/lazy.js
+++ b/src/node_types/lazy.js
@@ -11,7 +11,7 @@ export default function lazy(factory) {
 lazy.TYPE = TYPE
 
 
-register(TYPE, (next, processingContext, node, state, ...args) => {
+register(TYPE, (next, processingContext, node, ...args) => {
     const child = node.factory(...args)
-    return next(processingContext, child, state)
+    return next(processingContext, child)
 })

--- a/src/node_types/lazy.js
+++ b/src/node_types/lazy.js
@@ -11,7 +11,7 @@ export default function lazy(factory) {
 lazy.TYPE = TYPE
 
 
-register(TYPE, (next, context, node, state, props, ...args) => {
+register(TYPE, (next, context, node, state, ...args) => {
     const child = node.factory(...args)
-    return next(context, child, state, props)
+    return next(context, child, state)
 })

--- a/src/node_types/lazy.js
+++ b/src/node_types/lazy.js
@@ -9,8 +9,8 @@ export default register({
             factory,
         }
     },
-    nodeProcessor(next, processingContext, node, ...args) {
+    nodeProcessor(next, scope, node, ...args) {
         const child = node.factory(...args)
-        return next(processingContext, child)
+        return next(scope, child)
     },
 })

--- a/src/node_types/lazy.js
+++ b/src/node_types/lazy.js
@@ -1,3 +1,4 @@
+import { register } from '../processor'
 const TYPE = 'lazy'
 
 export default function lazy(factory) {
@@ -8,3 +9,9 @@ export default function lazy(factory) {
 }
 
 lazy.TYPE = TYPE
+
+
+register(TYPE, (next, context, node, state, props, ...args) => {
+    const child = node.factory(...args)
+    return next(context, child, state, props)
+})

--- a/src/node_types/lazy.js
+++ b/src/node_types/lazy.js
@@ -11,7 +11,7 @@ export default function lazy(factory) {
 lazy.TYPE = TYPE
 
 
-register(TYPE, (next, context, node, state, ...args) => {
+register(TYPE, (next, processingContext, node, state, ...args) => {
     const child = node.factory(...args)
-    return next(context, child, state)
+    return next(processingContext, child, state)
 })

--- a/src/node_types/lazy.js
+++ b/src/node_types/lazy.js
@@ -1,17 +1,16 @@
 import { register } from '../processor'
 const TYPE = 'lazy'
 
-export default function lazy(factory) {
-    return {
-        TYPE,
-        factory,
-    }
-}
-
-lazy.TYPE = TYPE
-
-
-register(TYPE, (next, processingContext, node, ...args) => {
-    const child = node.factory(...args)
-    return next(processingContext, child)
+export default register({
+    TYPE,
+    factory(factory) {
+        return {
+            TYPE,
+            factory,
+        }
+    },
+    nodeProcessor(next, processingContext, node, ...args) {
+        const child = node.factory(...args)
+        return next(processingContext, child)
+    },
 })

--- a/src/node_types/loader.js
+++ b/src/node_types/loader.js
@@ -26,7 +26,7 @@ export default function loader(options = {}) {
 
 loader.TYPE = TYPE
 
-register(TYPE, (next, context, node, state, props, ...args) => {
+register(TYPE, (next, context, node, state, ...args) => {
     const id = node.id(...args)
     if (typeof id !== 'string') {
         throw new Error('Loader failed to return an id')

--- a/src/node_types/loader.js
+++ b/src/node_types/loader.js
@@ -25,21 +25,21 @@ export default register({
             lazy,
         }
     },
-    nodeProcessor(next, processingContext, node, ...args) {
+    nodeProcessor(next, scope, node, ...args) {
         const id = node.id(...args)
         if (typeof id !== 'string') {
             throw new Error('Loader failed to return an id')
         }
         let value
 
-        const isReady = node.lazy === true || selectIsReady(processingContext.state, id)
+        const isReady = node.lazy === true || selectIsReady(scope.state, id)
 
         // Always queue the action. The component can choose whether or not to
         // call it.
-        processingContext.queue(id, node.action, args)
+        scope.queue(id, node.action, args)
 
         if (isReady) {
-            value = node.selector(processingContext.state, ...args)
+            value = node.selector(scope.state, ...args)
         }
 
         return {

--- a/src/node_types/loader.js
+++ b/src/node_types/loader.js
@@ -26,21 +26,21 @@ export default function loader(options = {}) {
 
 loader.TYPE = TYPE
 
-register(TYPE, (next, processingContext, node, state, ...args) => {
+register(TYPE, (next, processingContext, node, ...args) => {
     const id = node.id(...args)
     if (typeof id !== 'string') {
         throw new Error('Loader failed to return an id')
     }
     let value
 
-    const isReady = node.lazy === true || selectIsReady(state, id)
+    const isReady = node.lazy === true || selectIsReady(processingContext.state, id)
 
     // Always queue the action. The component can choose whether or not to
     // call it.
     processingContext.queue(id, node.action, args)
 
     if (isReady) {
-        value = node.selector(state, ...args)
+        value = node.selector(processingContext.state, ...args)
     }
 
     return {

--- a/src/node_types/loader.js
+++ b/src/node_types/loader.js
@@ -1,3 +1,5 @@
+import { register } from '../processor'
+import { selectIsReady } from '../actions-reducer'
 const TYPE = 'loader'
 
 export default function loader(options = {}) {
@@ -23,3 +25,26 @@ export default function loader(options = {}) {
 }
 
 loader.TYPE = TYPE
+
+register(TYPE, (next, context, node, state, props, ...args) => {
+    const id = node.id(...args)
+    if (typeof id !== 'string') {
+        throw new Error('Loader failed to return an id')
+    }
+    let value
+
+    const isReady = node.lazy === true || selectIsReady(state, id)
+
+    // Always queue the action. The component can choose whether or not to
+    // call it.
+    context.queue(id, node.action, args)
+
+    if (isReady) {
+        value = node.selector(state, ...args)
+    }
+
+    return {
+        isReady,
+        value,
+    }
+})

--- a/src/node_types/loader.js
+++ b/src/node_types/loader.js
@@ -26,7 +26,7 @@ export default function loader(options = {}) {
 
 loader.TYPE = TYPE
 
-register(TYPE, (next, context, node, state, ...args) => {
+register(TYPE, (next, processingContext, node, state, ...args) => {
     const id = node.id(...args)
     if (typeof id !== 'string') {
         throw new Error('Loader failed to return an id')
@@ -37,7 +37,7 @@ register(TYPE, (next, context, node, state, ...args) => {
 
     // Always queue the action. The component can choose whether or not to
     // call it.
-    context.queue(id, node.action, args)
+    processingContext.queue(id, node.action, args)
 
     if (isReady) {
         value = node.selector(state, ...args)

--- a/src/node_types/preload.js
+++ b/src/node_types/preload.js
@@ -25,7 +25,7 @@ preload.useProps = (function useProps() {
     return useProps
 }())
 
-register(TYPE, (next, processingContext, node, state, ...args) => {
+register(TYPE, (next, processingContext, node, ...args) => {
     const children = node.factory(preload.useProps, ...args)
 
     if (!Array.isArray(children)) {
@@ -41,17 +41,17 @@ register(TYPE, (next, processingContext, node, state, ...args) => {
 
     const child = group(children)
 
-    const { isReady } = next(processingContext, child, state)
+    const { isReady } = next(processingContext, child)
     return {
         excludeProp: true,
         isReady,
     }
 })
 
-register(preload.useProps.TYPE, (next, processingContext, node, state, ...args) => {
+register(preload.useProps.TYPE, (next, processingContext, node, ...args) => {
     const childProcessingContext = {
         ...processingContext,
         props: node.props,
     }
-    return next(childProcessingContext, node.child, state, ...args)
+    return next(childProcessingContext, node.child, ...args)
 })

--- a/src/node_types/preload.js
+++ b/src/node_types/preload.js
@@ -15,12 +15,12 @@ const useProps = (function useProps() {
                 child,
             }
         },
-        nodeProcessor(next, processingContext, node, ...args) {
-            const childProcessingContext = {
-                ...processingContext,
+        nodeProcessor(next, scope, node, ...args) {
+            const childScope = {
+                ...scope,
                 props: node.props,
             }
-            return next(childProcessingContext, node.child, ...args)
+            return next(childScope, node.child, ...args)
         },
     })
 }())
@@ -33,7 +33,7 @@ const preload = register({
             factory,
         }
     },
-    nodeProcessor(next, processingContext, node, ...args) {
+    nodeProcessor(next, scope, node, ...args) {
         const children = node.factory(useProps, ...args)
 
         if (!Array.isArray(children)) {
@@ -49,7 +49,7 @@ const preload = register({
 
         const child = group(children)
 
-        const { isReady } = next(processingContext, child)
+        const { isReady } = next(scope, child)
         return {
             excludeProp: true,
             isReady,

--- a/src/node_types/preload.js
+++ b/src/node_types/preload.js
@@ -25,7 +25,7 @@ preload.useProps = (function useProps() {
     return useProps
 }())
 
-register(TYPE, (next, context, node, state, ...args) => {
+register(TYPE, (next, processingContext, node, state, ...args) => {
     const children = node.factory(preload.useProps, ...args)
 
     if (!Array.isArray(children)) {
@@ -41,17 +41,17 @@ register(TYPE, (next, context, node, state, ...args) => {
 
     const child = group(children)
 
-    const { isReady } = next(context, child, state)
+    const { isReady } = next(processingContext, child, state)
     return {
         excludeProp: true,
         isReady,
     }
 })
 
-register(preload.useProps.TYPE, (next, context, node, state, ...args) => {
-    const childContext = {
-        ...context,
+register(preload.useProps.TYPE, (next, processingContext, node, state, ...args) => {
+    const childProcessingContext = {
+        ...processingContext,
         props: node.props,
     }
-    return next(childContext, node.child, state, ...args)
+    return next(childProcessingContext, node.child, state, ...args)
 })

--- a/src/node_types/preload.js
+++ b/src/node_types/preload.js
@@ -25,7 +25,7 @@ preload.useProps = (function useProps() {
     return useProps
 }())
 
-register(TYPE, (next, context, node, state, props, ...args) => {
+register(TYPE, (next, context, node, state, ...args) => {
     const children = node.factory(preload.useProps, ...args)
 
     if (!Array.isArray(children)) {
@@ -41,13 +41,17 @@ register(TYPE, (next, context, node, state, props, ...args) => {
 
     const child = group(children)
 
-    const { isReady } = next(context, child, state, props)
+    const { isReady } = next(context, child, state)
     return {
         excludeProp: true,
         isReady,
     }
 })
 
-register(preload.useProps.TYPE, (next, context, node, state, props, ...args) => {
-    return next(context, node.child, state, node.props, ...args)
+register(preload.useProps.TYPE, (next, context, node, state, ...args) => {
+    const childContext = {
+        ...context,
+        props: node.props,
+    }
+    return next(childContext, node.child, state, ...args)
 })

--- a/src/node_types/selector.js
+++ b/src/node_types/selector.js
@@ -14,7 +14,7 @@ export default function selector(select) {
 }
 selector.TYPE = TYPE
 
-register(TYPE, (next, context, node, state, props, ...args) => {
+register(TYPE, (next, context, node, state, ...args) => {
     return {
         isReady: true,
         value: node.select(state, ...args),

--- a/src/node_types/selector.js
+++ b/src/node_types/selector.js
@@ -1,3 +1,4 @@
+import { register } from '../processor.js'
 
 const TYPE = 'selector'
 
@@ -12,3 +13,10 @@ export default function selector(select) {
     }
 }
 selector.TYPE = TYPE
+
+register(TYPE, (next, context, node, state, props, ...args) => {
+    return {
+        isReady: true,
+        value: node.select(state, ...args),
+    }
+})

--- a/src/node_types/selector.js
+++ b/src/node_types/selector.js
@@ -14,9 +14,9 @@ export default function selector(select) {
 }
 selector.TYPE = TYPE
 
-register(TYPE, (next, processingContext, node, state, ...args) => {
+register(TYPE, (next, processingContext, node, ...args) => {
     return {
         isReady: true,
-        value: node.select(state, ...args),
+        value: node.select(processingContext.state, ...args),
     }
 })

--- a/src/node_types/selector.js
+++ b/src/node_types/selector.js
@@ -2,21 +2,22 @@ import { register } from '../processor.js'
 
 const TYPE = 'selector'
 
-export default function selector(select) {
-    if (typeof select !== 'function') {
-        throw new Error('Missing selector')
-    }
+export default register({
+    TYPE,
+    factory(select) {
+        if (typeof select !== 'function') {
+            throw new Error('Missing selector')
+        }
 
-    return {
-        TYPE,
-        select,
-    }
-}
-selector.TYPE = TYPE
-
-register(TYPE, (next, processingContext, node, ...args) => {
-    return {
-        isReady: true,
-        value: node.select(processingContext.state, ...args),
-    }
+        return {
+            TYPE,
+            select,
+        }
+    },
+    nodeProcessor(next, processingContext, node, ...args) {
+        return {
+            isReady: true,
+            value: node.select(processingContext.state, ...args),
+        }
+    },
 })

--- a/src/node_types/selector.js
+++ b/src/node_types/selector.js
@@ -14,7 +14,7 @@ export default function selector(select) {
 }
 selector.TYPE = TYPE
 
-register(TYPE, (next, context, node, state, ...args) => {
+register(TYPE, (next, processingContext, node, state, ...args) => {
     return {
         isReady: true,
         value: node.select(state, ...args),

--- a/src/node_types/selector.js
+++ b/src/node_types/selector.js
@@ -14,10 +14,10 @@ export default register({
             select,
         }
     },
-    nodeProcessor(next, processingContext, node, ...args) {
+    nodeProcessor(next, scope, node, ...args) {
         return {
             isReady: true,
-            value: node.select(processingContext.state, ...args),
+            value: node.select(scope.state, ...args),
         }
     },
 })

--- a/src/node_types/virtual.js
+++ b/src/node_types/virtual.js
@@ -1,3 +1,4 @@
+import { register } from '../processor'
 import normalize from './normalize.js'
 const TYPE = 'virtual'
 
@@ -12,3 +13,12 @@ export default function virtual(child) {
     }
 }
 virtual.TYPE = TYPE
+
+register(TYPE, (next, context, node, state, props, ...args) => {
+    const value = next(context, node.child, state, props, ...args)
+
+    return {
+        ...value,
+        excludeProp: true,
+    }
+})

--- a/src/node_types/virtual.js
+++ b/src/node_types/virtual.js
@@ -14,8 +14,8 @@ export default function virtual(child) {
 }
 virtual.TYPE = TYPE
 
-register(TYPE, (next, processingContext, node, state, ...args) => {
-    const value = next(processingContext, node.child, state, ...args)
+register(TYPE, (next, processingContext, node, ...args) => {
+    const value = next(processingContext, node.child, ...args)
 
     return {
         ...value,

--- a/src/node_types/virtual.js
+++ b/src/node_types/virtual.js
@@ -2,23 +2,24 @@ import { register } from '../processor'
 import normalize from './normalize.js'
 const TYPE = 'virtual'
 
-export default function virtual(child) {
-    if (child == null) {
-        throw new Error('Missing child')
-    }
+export default register({
+    TYPE,
+    factory(child) {
+        if (child == null) {
+            throw new Error('Missing child')
+        }
 
-    return {
-        TYPE,
-        child: normalize(child),
-    }
-}
-virtual.TYPE = TYPE
+        return {
+            TYPE,
+            child: normalize(child),
+        }
+    },
+    nodeProcessor(next, processingContext, node, ...args) {
+        const value = next(processingContext, node.child, ...args)
 
-register(TYPE, (next, processingContext, node, ...args) => {
-    const value = next(processingContext, node.child, ...args)
-
-    return {
-        ...value,
-        excludeProp: true,
-    }
+        return {
+            ...value,
+            excludeProp: true,
+        }
+    },
 })

--- a/src/node_types/virtual.js
+++ b/src/node_types/virtual.js
@@ -14,8 +14,8 @@ export default function virtual(child) {
 }
 virtual.TYPE = TYPE
 
-register(TYPE, (next, context, node, state, props, ...args) => {
-    const value = next(context, node.child, state, props, ...args)
+register(TYPE, (next, context, node, state, ...args) => {
+    const value = next(context, node.child, state, ...args)
 
     return {
         ...value,

--- a/src/node_types/virtual.js
+++ b/src/node_types/virtual.js
@@ -14,8 +14,8 @@ export default register({
             child: normalize(child),
         }
     },
-    nodeProcessor(next, processingContext, node, ...args) {
-        const value = next(processingContext, node.child, ...args)
+    nodeProcessor(next, scope, node, ...args) {
+        const value = next(scope, node.child, ...args)
 
         return {
             ...value,

--- a/src/node_types/virtual.js
+++ b/src/node_types/virtual.js
@@ -14,8 +14,8 @@ export default function virtual(child) {
 }
 virtual.TYPE = TYPE
 
-register(TYPE, (next, context, node, state, ...args) => {
-    const value = next(context, node.child, state, ...args)
+register(TYPE, (next, processingContext, node, state, ...args) => {
+    const value = next(processingContext, node.child, state, ...args)
 
     return {
         ...value,

--- a/src/processor.js
+++ b/src/processor.js
@@ -1,37 +1,37 @@
 /* eslint-disable no-console */
 const visitors = {}
 
-function next(context, node, state, ...args) {
+function next(processingContext, node, state, ...args) {
     if (!visitors[node.TYPE]) {
         console.log(node)
         throw new Error(`Invalid type: ${String(node.TYPE)}`)
     }
 
-    const { debug } = context
+    const { debug } = processingContext
 
     let value
 
     if (debug) {
-        const groupName = `${node.TYPE}: ${context.path.join('.')}`
+        const groupName = `${node.TYPE}: ${processingContext.path.join('.')}`
 
         console.groupCollapsed(groupName)
         console.log('node: ', node)
         if (args.length > 0) {
             console.log('...args: ', ...args)
         }
-        value = visitors[node.TYPE](next, context, node, state, ...args)
+        value = visitors[node.TYPE](next, processingContext, node, state, ...args)
         console.log('isReady', value.isReady)
         console.log('value', value.value)
         console.groupEnd(groupName)
     } else {
-        value = visitors[node.TYPE](next, context, node, state, ...args)
+        value = visitors[node.TYPE](next, processingContext, node, state, ...args)
     }
     return value
 }
 
 export default function processor(node, state, props) {
     const actionQueue = []
-    const context = {
+    const processingContext = {
         debug: false,
         queue(id, action, args) {
             if (this.debug) {
@@ -43,7 +43,7 @@ export default function processor(node, state, props) {
         props,
     }
 
-    const value = next(context, node, state)
+    const value = next(processingContext, node, state)
 
     return {
         ...value,

--- a/src/processor.js
+++ b/src/processor.js
@@ -1,176 +1,5 @@
-import depends from './node_types/depends'
-import group from './node_types/group'
-import loader from './node_types/loader'
-import preload from './node_types/preload'
-import selector from './node_types/selector'
-import debug from './node_types/debug'
-import virtual from './node_types/virtual'
-import lazy from './node_types/lazy'
-import { reduce } from './utils'
-import { selectIsReady } from './actions-reducer.js'
-
 /* eslint-disable no-console */
-/* eslint-disable no-use-before-define */
-const visitors = {
-    [loader.TYPE](context, node, state, props, ...args) {
-        const id = node.id(...args)
-        if (typeof id !== 'string') {
-            throw new Error('Loader failed to return an id')
-        }
-        let value
-
-        const isReady = node.lazy === true || selectIsReady(state, id)
-
-        // Always queue the action. The component can choose whether or not to
-        // call it.
-        context.queue(id, node.action, args)
-
-        if (isReady) {
-            value = node.selector(state, ...args)
-        }
-
-        return {
-            isReady,
-            value,
-        }
-    },
-    [virtual.TYPE](context, node, state, props, ...args) {
-        const value = next(context, node.child, state, props, ...args)
-
-        return {
-            ...value,
-            excludeProp: true,
-        }
-    },
-    [lazy.TYPE](context, node, state, props, ...args) {
-        const child = node.factory(...args)
-        return next(context, child, state, props)
-    },
-    [preload.TYPE](context, node, state, props, ...args) {
-        const children = node.factory(preload.useProps, ...args)
-
-        if (!Array.isArray(children)) {
-            throw new Error('Preload must return an array of nodes to process')
-        }
-
-        if (Array.isArray(children) && children.length === 0) {
-            return {
-                isReady: true,
-                excludeProp: true,
-            }
-        }
-
-        const child = group(children)
-
-        const { isReady } = next(context, child, state, props)
-        return {
-            excludeProp: true,
-            isReady,
-        }
-    },
-    [preload.useProps.TYPE](context, node, state, props, ...args) {
-        return next(context, node.child, state, node.props, ...args)
-    },
-    [depends.TYPE](context, node, state, props) {
-        let isReady = true
-
-        if (context.debug) {
-            console.log('node.dependencies: ', ...node.dependencies)
-        }
-
-        const args = node.dependencies.map(dep => {
-            if (isReady === false) return null
-
-            if (dep.type === 'value') {
-                return dep.value
-            }
-
-            const path = dep.path.split('.')
-            let root
-            if (dep.type === 'prop') {
-                root = props
-            } else if (dep.type === 'resource') {
-                const key = path.shift()
-                const resource = context.resources[key]
-
-                if (resource.isReady) {
-                    root = resource.value
-                } else {
-                    isReady = false
-                    return null
-                }
-            }
-
-            return path.reduce(
-                (value, next) => (value != null ? value[next] : null),
-                root
-            )
-        })
-
-        if (!isReady) {
-            return {
-                isReady,
-            }
-        }
-
-        return next(context, node.child, state, props, ...args)
-    },
-    [selector.TYPE](context, node, state, props, ...args) {
-        return {
-            isReady: true,
-            value: node.select(state, ...args),
-        }
-    },
-    [group.TYPE](context, node, state, props) {
-        const resources = {}
-        const { path } = context
-
-        const results = reduce(
-            node.children,
-            (x, child, key) => {
-                const childContext = {
-                    ...context,
-                    resources,
-                    path: [...path, key],
-                }
-                const result = resources[key] = next(childContext, child, state, props)
-                const { isReady, value, excludeProp } = result
-
-                if (excludeProp === true || !isReady) {
-                    return {
-                        ...x,
-                        isReady: x.isReady && isReady,
-                    }
-                }
-
-                const nextValue = Array.isArray(node.children) ?
-                    [...x.value, value] :
-                    { ...x.value, [key]: value }
-
-                return {
-                    isReady: x.isReady && isReady,
-                    value: nextValue,
-                }
-            },
-            { isReady: true, value: Array.isArray(node.children) ? [] : {} }
-        )
-
-        return results
-    },
-    [debug.TYPE](context, node, state, props) {
-        const childContext = {
-            ...context,
-            debug: true,
-        }
-
-        try {
-            console.groupCollapsed('DEBUG')
-            return next(childContext, node.child, state, props)
-        } finally {
-            console.groupEnd('DEBUG')
-        }
-    },
-}
+const visitors = {}
 
 function next(context, node, state, props, ...args) {
     if (!visitors[node.TYPE]) {
@@ -190,18 +19,12 @@ function next(context, node, state, props, ...args) {
         if (args.length > 0) {
             console.log('...args: ', ...args)
         }
-        try {
-            value = visitors[node.TYPE](context, node, state, props, ...args)
-        } catch (e) {
-            console.error(e)
-            throw e
-        } finally {
-            console.log('isReady', value.isReady)
-            console.log('value', value.value)
-            console.groupEnd(groupName)
-        }
+        value = visitors[node.TYPE](next, context, node, state, props, ...args)
+        console.log('isReady', value.isReady)
+        console.log('value', value.value)
+        console.groupEnd(groupName)
     } else {
-        value = visitors[node.TYPE](context, node, state, props, ...args)
+        value = visitors[node.TYPE](next, context, node, state, props, ...args)
     }
     return value
 }
@@ -225,4 +48,11 @@ export default function processor(node, state, props) {
         ...value,
         actionQueue,
     }
+}
+
+export const register = (type, implemenation) => {
+    if (visitors[type]) {
+        throw new Error(`visitor ${type} is already registered`)
+    }
+    visitors[type] = implemenation
 }

--- a/src/processor.js
+++ b/src/processor.js
@@ -1,7 +1,7 @@
 /* eslint-disable no-console */
 const visitors = {}
 
-function next(processingContext, node, state, ...args) {
+function next(processingContext, node, ...args) {
     if (!visitors[node.TYPE]) {
         console.log(node)
         throw new Error(`Invalid type: ${String(node.TYPE)}`)
@@ -19,12 +19,12 @@ function next(processingContext, node, state, ...args) {
         if (args.length > 0) {
             console.log('...args: ', ...args)
         }
-        value = visitors[node.TYPE](next, processingContext, node, state, ...args)
+        value = visitors[node.TYPE](next, processingContext, node, ...args)
         console.log('isReady', value.isReady)
         console.log('value', value.value)
         console.groupEnd(groupName)
     } else {
-        value = visitors[node.TYPE](next, processingContext, node, state, ...args)
+        value = visitors[node.TYPE](next, processingContext, node, ...args)
     }
     return value
 }
@@ -32,6 +32,8 @@ function next(processingContext, node, state, ...args) {
 export default function processor(node, state, props) {
     const actionQueue = []
     const processingContext = {
+        props,
+        state,
         debug: false,
         queue(id, action, args) {
             if (this.debug) {
@@ -40,10 +42,9 @@ export default function processor(node, state, props) {
             actionQueue.push({ id, action, args, debug: this.debug })
         },
         path: ['root'],
-        props,
     }
 
-    const value = next(processingContext, node, state)
+    const value = next(processingContext, node)
 
     return {
         ...value,

--- a/src/processor.js
+++ b/src/processor.js
@@ -1,7 +1,7 @@
 /* eslint-disable no-console */
 const visitors = {}
 
-function next(context, node, state, props, ...args) {
+function next(context, node, state, ...args) {
     if (!visitors[node.TYPE]) {
         console.log(node)
         throw new Error(`Invalid type: ${String(node.TYPE)}`)
@@ -19,12 +19,12 @@ function next(context, node, state, props, ...args) {
         if (args.length > 0) {
             console.log('...args: ', ...args)
         }
-        value = visitors[node.TYPE](next, context, node, state, props, ...args)
+        value = visitors[node.TYPE](next, context, node, state, ...args)
         console.log('isReady', value.isReady)
         console.log('value', value.value)
         console.groupEnd(groupName)
     } else {
-        value = visitors[node.TYPE](next, context, node, state, props, ...args)
+        value = visitors[node.TYPE](next, context, node, state, ...args)
     }
     return value
 }
@@ -40,9 +40,10 @@ export default function processor(node, state, props) {
             actionQueue.push({ id, action, args, debug: this.debug })
         },
         path: ['root'],
+        props,
     }
 
-    const value = next(context, node, state, props)
+    const value = next(context, node, state)
 
     return {
         ...value,

--- a/src/processor.js
+++ b/src/processor.js
@@ -52,9 +52,19 @@ export default function processor(node, state, props) {
     }
 }
 
-export const register = (type, implemenation) => {
-    if (visitors[type]) {
-        throw new Error(`visitor ${type} is already registered`)
+export const register = ({ TYPE, factory, nodeProcessor }) => {
+    if (!TYPE) { throw new Error('missing TYPE') }
+    if (!factory) { throw new Error('missing factory') }
+    if (!nodeProcessor) { throw new Error('missing nodeProcessor') }
+    if (visitors[TYPE]) {
+        throw new Error(`visitor ${TYPE} is already registered`)
     }
-    visitors[type] = implemenation
+    visitors[TYPE] = nodeProcessor
+
+    // It's useful to attach the nodeProcessor and type for testing purposes.
+    factory.nodeProcessor = nodeProcessor
+    factory.TYPE = TYPE
+
+    // the factory is the only piece users interact with, so return it directly
+    return factory
 }


### PR DESCRIPTION
The first goal of this PR is to allow registering node types instead of implementing them all in `src/processor.js`. This was also a good time to rename `context` to `processingContext` to avoid confusion with React's context.

This seemed like a good opportunity to move `props` and `state` into `processingContext` as they're used by very few nodes.

I think it might make sense to move `...args` into the context, but that's going to require some more thought. I don't think passing `...args` through `group()` makes any sense, so that probably shouldn't work. `...args` moves unmodified through `lazy()`, but then are consumed by `loader()` and `selector()`.