### PR TITLE
New Feature: refreshCache action

### DIFF
--- a/src/actions-reducer.js
+++ b/src/actions-reducer.js
@@ -1,5 +1,6 @@
 export const ACTION_DONE = '@@fetchTree/action_done'
 export const STORE_ENTITY = '@@fetchTree/store_entity'
+export const REFRESH_CACHE = '@@fetchTree/refresh_cache'
 
 export const setActionStatusDone = (id) => ({
     type: ACTION_DONE,
@@ -10,6 +11,8 @@ export const storeEntity = (id, value) => ({
     type: STORE_ENTITY,
     payload: { id, value },
 })
+
+export const refreshCache = () => ({ type: REFRESH_CACHE })
 
 export const selectEntity = (state, id) => (
     state.fetchTree != null
@@ -23,6 +26,11 @@ export const selectIsReady = (state, id) => Boolean(
     && state.fetchTree.ready[id] != null
 )
 
+export const selectCacheKey = (state) => (
+    (state.fetchTree != null)
+        ? state.fetchTree.cacheKey
+        : 0
+)
 
 function readyReducer(state = {}, action) {
     if (action.type === ACTION_DONE) {
@@ -47,12 +55,18 @@ function entityReducer(state = {}, action) {
 
 
 const defaultState = {
+    cacheKey: 0,
     ready: readyReducer(undefined, { type: '__init__' }),
     entities: entityReducer(undefined, { type: '__init__' }),
 }
 
 export default function reducer(state = defaultState, action) {
     switch (action.type) {
+        case REFRESH_CACHE:
+            return {
+                ...state,
+                cacheKey: state.cacheKey + 1,
+            }
         case ACTION_DONE:
             return {
                 ...state,

--- a/src/component.jsx
+++ b/src/component.jsx
@@ -6,6 +6,7 @@ import loaderContext from './loader_context'
 import processor from './processor'
 import withContext from './node_types/with-context'
 import withDispatch from './node_types/with-dispatch'
+import { selectCacheKey } from './actions-reducer.js'
 
 const getDisplayName = Component => (
   Component.displayName ||
@@ -26,6 +27,7 @@ const IS_READY = '--loader:is-ready'
 const ACTION_QUEUE = '--loader:action-queue'
 const DISPATCH = '--loader:dispatch'
 const DISPATCH_PROXY = '--loader:dispatchProxy'
+const CACHE_KEY = '--loader:cacheKey'
 
 function nonConnectedWrapper({ component: Component, resourceGroup }) {
     function NonConnectedFetchTree(props) {
@@ -111,8 +113,9 @@ export default function fetchTree(options) {
             const {
                 [ACTION_QUEUE]: actionQueue,
                 [DISPATCH]: dispatch,
+                [CACHE_KEY]: cacheKey,
             } = this.props
-            this.loaderContext.execute(dispatch, actionQueue)
+            this.loaderContext.execute(dispatch, actionQueue, cacheKey)
         }
 
         componentWillReceiveProps(nextProps) {
@@ -127,8 +130,9 @@ export default function fetchTree(options) {
             const {
                 [ACTION_QUEUE]: actionQueue,
                 [DISPATCH]: dispatch,
+                [CACHE_KEY]: cacheKey,
             } = this.props
-            this.loaderContext.execute(dispatch, actionQueue)
+            this.loaderContext.execute(dispatch, actionQueue, cacheKey)
         }
 
         render() {
@@ -136,6 +140,7 @@ export default function fetchTree(options) {
                 [IS_READY]: isReady,
                 [ACTION_QUEUE]: ignoredActionQueue,
                 [DISPATCH_PROXY]: ignoredDispatchProxy,
+                [CACHE_KEY]: ignoredCacheCounter,
                 ...props
             } = this.props
 
@@ -168,6 +173,7 @@ export default function fetchTree(options) {
         }
 
         return (state, props) => {
+            const cacheKey = selectCacheKey(state)
             const localResources = withContext('path', [LoaderComponent.displayName || 'Component'],
                 withContext('props', props,
                     withDispatch(dispatchProxy, resourceGroup)
@@ -180,6 +186,7 @@ export default function fetchTree(options) {
                 [IS_READY]: isReady,
                 [ACTION_QUEUE]: actionQueue,
                 [DISPATCH_PROXY]: dispatchProxy,
+                [CACHE_KEY]: cacheKey,
             }
         }
     }

--- a/src/index.js
+++ b/src/index.js
@@ -13,13 +13,14 @@ import dispatch from './node_types/dispatch'
 import fromProps from './node_types/from-props'
 
 import component from './component'
-import reducer from './actions-reducer'
+import reducer, { refreshCache } from './actions-reducer'
 
 import { register as registerNodeType } from './processor.js'
 
 export { group, loader, selector, depends, reducer, debug, virtual, entity, withContext }
 export { withDispatch, dispatch }
 export { child, withProps, fromProps }
+export { refreshCache }
 
 export { registerNodeType }
 export default component

--- a/src/loader_context.js
+++ b/src/loader_context.js
@@ -5,15 +5,16 @@ export default function (parent) {
     }
     const executedIds = new Map()
 
-    function hasExecuted(id) {
-        return executedIds.has(id) || (
-            parent != null ? parent.hasExecuted(id) : false
+    function hasExecuted(id, cacheKey) {
+        return (
+            (executedIds.has(id) && executedIds.get(id) === cacheKey)
+            || (parent != null ? parent.hasExecuted(id, cacheKey) : false)
         )
     }
 
-    function execute(dispatch, actions) {
+    function execute(dispatch, actions, cacheKey) {
         actions.forEach(({ id, action, args, debug }) => {
-            if (!hasExecuted(id)) {
+            if (!hasExecuted(id, cacheKey)) {
                 let tmp
                 if (debug) {
                     /* eslint-disable no-console */
@@ -32,7 +33,7 @@ export default function (parent) {
                 } else {
                     tmp = dispatch(action(...args))
                 }
-                executedIds.set(id, true)
+                executedIds.set(id, cacheKey)
 
                 if (!tmp || !tmp.then) {
                     // Use the thunk middleware and return a promise from the thunk.


### PR DESCRIPTION
Dispatching a `refreshCache()` will cause all `loaderContext` to discard the
current cache and allow FetchTree to fetch fresh copies of any data.