### PR TITLE
add mockNode(node, fn) and resetMocks()

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -16,7 +16,8 @@ import mockNode from './node_types/mock-node'
 import component from './component'
 import reducer, { refreshCache } from './actions-reducer'
 
-import { register as registerNodeType, resetMocks } from './processor.js'
+import { register as registerNodeType } from './processor.js'
+import { resetMocks } from './mocks'
 
 export { group, loader, selector, depends, reducer, debug, virtual, entity, withContext }
 export { withDispatch, dispatch }

--- a/src/index.js
+++ b/src/index.js
@@ -11,16 +11,18 @@ import withProps from './node_types/with-props'
 import withDispatch from './node_types/with-dispatch'
 import dispatch from './node_types/dispatch'
 import fromProps from './node_types/from-props'
+import mockNode from './node_types/mock-node'
 
 import component from './component'
 import reducer, { refreshCache } from './actions-reducer'
 
-import { register as registerNodeType } from './processor.js'
+import { register as registerNodeType, resetMocks } from './processor.js'
 
 export { group, loader, selector, depends, reducer, debug, virtual, entity, withContext }
 export { withDispatch, dispatch }
 export { child, withProps, fromProps }
 export { refreshCache }
+export { mockNode, resetMocks }
 
 export { registerNodeType }
 export default component

--- a/src/mocks.js
+++ b/src/mocks.js
@@ -1,0 +1,20 @@
+let mockedNodes
+export const hasMocks = () => mockedNodes != null
+export const resetMocks = () => { mockedNodes = undefined }
+export const hasMock = (node) => hasMocks() && mockedNodes.has(node)
+
+export function registerMock(node, mock) {
+    if (!hasMocks()) {
+        mockedNodes = new WeakMap()
+    }
+    mockedNodes.set(node, mock)
+}
+
+export function getMock(node) {
+    if (process.env.NODE_MODULES !== 'production') {
+        if (hasMocks() && mockedNodes.has(node)) {
+            return mockedNodes.get(node)
+        }
+    }
+    return node
+}

--- a/src/node_types/dispatch.js
+++ b/src/node_types/dispatch.js
@@ -21,7 +21,13 @@ export default register({
         if (!dispatch) {
             throw new Error(`No dispatch found on scope`)
         }
-        const { actionCreator } = node
+        let { actionCreator } = node
+        if (process.env.NODE_ENV !== 'production' && scope.hasMocks()) {
+            if (!scope.hasMock(actionCreator)) {
+                throw scope.missingMock('dispatch')
+            }
+            actionCreator = scope.getMock(actionCreator)
+        }
 
         const value = (...args) => dispatch(actionCreator(...args))
 

--- a/src/node_types/mock-node.js
+++ b/src/node_types/mock-node.js
@@ -1,4 +1,5 @@
-import { register, registerMock } from '../processor.js'
+import { register } from '../processor'
+import { registerMock } from '../mocks'
 
 const TYPE = 'mocked-node'
 const mockedNode = register({

--- a/src/node_types/mock-node.js
+++ b/src/node_types/mock-node.js
@@ -1,0 +1,27 @@
+import { register, registerMock } from '../processor.js'
+
+const TYPE = 'mocked-node'
+const mockedNode = register({
+    TYPE,
+    factory(original, fn) {
+        if (typeof fn !== 'function') {
+            throw new Error('You must x')
+        }
+
+        return {
+            TYPE,
+            original,
+            fn,
+        }
+    },
+    nodeProcessor(next, scope, node, ...args) {
+        return {
+            isReady: true,
+            value: node.fn(...args),
+        }
+    },
+})
+
+export default function mockNode(node, fn) {
+    registerMock(node, mockedNode(node, fn))
+}

--- a/src/node_types/mock-node.js
+++ b/src/node_types/mock-node.js
@@ -6,7 +6,7 @@ const mockedNode = register({
     TYPE,
     factory(original, fn) {
         if (typeof fn !== 'function') {
-            throw new Error('You must x')
+            throw new Error('missing function')
         }
 
         return {

--- a/src/node_types/selector.js
+++ b/src/node_types/selector.js
@@ -15,6 +15,16 @@ export default register({
         }
     },
     nodeProcessor(next, scope, node, ...args) {
+        if (process.env.NODE_ENV !== 'production' && scope.hasMocks()) {
+            if (!scope.hasMock(node.select)) {
+                throw scope.missingMock('dispatch')
+            }
+            const mock = scope.getMock(node.select)
+            return {
+                isReady: true,
+                value: mock(...args),
+            }
+        }
         return {
             isReady: true,
             value: node.select(scope.state, ...args),

--- a/src/processor.js
+++ b/src/processor.js
@@ -1,7 +1,24 @@
 /* eslint-disable no-console */
 const visitors = {}
 
+let mockedNodes
+export const resetMocks = () => { mockedNodes = undefined }
+
+export function registerMock(node, mock) {
+    if (mockedNodes == null) {
+        mockedNodes = new WeakMap()
+    }
+    mockedNodes.set(node, mock)
+}
+
+
 function next(processingContext, node, ...args) {
+    if (process.env.NODE_ENV !== 'production') {
+        if (mockedNodes != null && mockedNodes.has(node)) {
+            node = mockedNodes.get(node)
+        }
+    }
+
     if (!visitors[node.TYPE]) {
         console.log(node)
         throw new Error(`Invalid type: ${String(node.TYPE)}`)

--- a/test-example/tests/__snapshots__/mock-node.test.js.snap
+++ b/test-example/tests/__snapshots__/mock-node.test.js.snap
@@ -1,0 +1,69 @@
+exports[`test mockNode() will replace the way a node processes 1`] = `
+<ul>
+  <li>
+    <div>
+      id: 1
+      <input
+        checked={true}
+        type="checkbox" />
+      <p>
+        one
+      </p>
+    </div>
+  </li>
+  <li>
+    <div>
+      id: 2
+      <input
+        checked={true}
+        type="checkbox" />
+      <p>
+        two
+      </p>
+    </div>
+  </li>
+</ul>
+`;
+
+exports[`test mocking a mocked node replaces it 1`] = `
+<ul>
+  <li>
+    <div>
+      id: 1
+      <input
+        checked={true}
+        type="checkbox" />
+      <p>
+        second mock
+      </p>
+    </div>
+  </li>
+</ul>
+`;
+
+exports[`test resetMocks()) 1`] = `
+<ul>
+  <li>
+    <div>
+      id: 1
+      <input
+        checked={false}
+        type="checkbox" />
+      <p>
+        Fouti hi rovumjak wuwab ojki utemun ti voblom mefup ivkiz nadahuw ci.
+      </p>
+    </div>
+  </li>
+  <li>
+    <div>
+      id: 2
+      <input
+        checked={true}
+        type="checkbox" />
+      <p>
+        Bev rip asu rosob lo su za wirun kubvaw nadridzez cabfed temekuinu co.
+      </p>
+    </div>
+  </li>
+</ul>
+`;

--- a/test-example/tests/mock-node.test.js
+++ b/test-example/tests/mock-node.test.js
@@ -1,0 +1,111 @@
+import React from 'react'
+import td from 'testdouble'
+
+import { renderSnapshot } from './test-utils.js'
+import fetchTree, { group, fromProps, virtual, child, mockNode, resetMocks } from 'fetch-tree'
+
+import Leaf from '../src/components/todo'
+import Loading from '../src/components/loading'
+import { todoResource } from '../src/resources'
+
+afterEach(resetMocks)
+
+// This doesn't need a resourceGroup because it will use the one defined in Leaf
+const ConnectedLeaf = fetchTree({
+    component: Leaf,
+    busy: Loading,
+})
+
+function Root(props) {
+    return (
+        <ul>
+            {props.ids.map(id => (
+                <li key={id}>
+                    <ConnectedLeaf id={id} />
+                </li>
+            ))}
+        </ul>
+    )
+}
+
+const ConnectedRoot = fetchTree({
+    component: Root,
+    resourceGroup: group({
+        // virtual allows you to define nodes that don't get added to the props
+        idsForThisComponent: virtual(fromProps('ids')),
+        preloadLeaves: virtual(child(
+            ['idsForThisComponent'],
+            // While `ConnectedRoot` is holding a loading screen up, it loads
+            // the data for the connected children.
+            (ids) => ids.map(id => (
+                <ConnectedLeaf id={id} />
+            ))
+        )),
+
+    }),
+})
+
+test(`mockNode() will replace the way a node processes`, async () => {
+    mockNode(todoResource, (id) => {
+        let note
+        // You can check your parameters any way you want.
+        if (id === 1) {
+            note = 'one'
+        } else if (id === 2) {
+            note = 'two'
+        } else {
+            throw new Error('')
+        }
+        return {
+            id,
+            done: true,
+            note,
+        }
+    })
+    const report = await renderSnapshot(
+        <ConnectedRoot ids={[1, 2]} />
+    )
+
+    expect(report.apiRequests).toEqual({})
+    // Nothing needed to be fetched, so it was able to render immediately.
+    expect(report.loadingScreens).toBe(0)
+})
+
+
+test(`resetMocks())`, async () => {
+    mockNode(todoResource, (id) => {
+        return { id, done: true, note: 'whatever' }
+    })
+
+    resetMocks()
+    const report = await renderSnapshot(
+        <ConnectedRoot ids={[1, 2]} />
+    )
+
+    expect(report.apiRequests).toEqual({
+        fetchTodo: 2,
+    })
+    // Nothing needed to be fetched, so it was able to render immediately.
+    expect(report.loadingScreens).toBe(1)
+})
+
+test(`mocking a mocked node replaces it`, async () => {
+    const mock1 = td.function('.mock1')
+    const mock2 = td.function('.mock2')
+    td.when(mock2(1)).thenReturn({
+        id: 1, done: true, note: 'second mock',
+    })
+
+    mockNode(todoResource, mock1)
+    mockNode(todoResource, mock2)
+
+    const report = await renderSnapshot(
+        <ConnectedRoot ids={[1]} />
+    )
+
+    td.verify(mock1(), { ignoreExtraArgs: true, times: 0 })
+
+    expect(report.apiRequests).toEqual({})
+    // Nothing needed to be fetched, so it was able to render immediately.
+    expect(report.loadingScreens).toBe(0)
+})

--- a/test-example/tests/mock-node.test.js
+++ b/test-example/tests/mock-node.test.js
@@ -85,7 +85,6 @@ test(`resetMocks())`, async () => {
     expect(report.apiRequests).toEqual({
         fetchTodo: 2,
     })
-    // Nothing needed to be fetched, so it was able to render immediately.
     expect(report.loadingScreens).toBe(1)
 })
 


### PR DESCRIPTION
Initially I had planned to pass the mocked nodes to the top component you're rendering. That process only works if you only have a single connected root. Passing it down through React's context would have required wrapping every fetch tree node in yet another component to capture the context and pass it down as a prop. I didn't consider this worth the effort and overhead.

What I landed on is simply having FetchTree keep an internal record of mocked nodes that you should reset between tests. In jest `afterEach(resetMocks)` is fine. In storybook we will probably need a decorator that resets before tests and then sets all of the mocks.