### PR TITLE
Add defaults to `fromProps()`

### DIFF
--- a/.watchmanconfig
+++ b/.watchmanconfig
@@ -1,0 +1,3 @@
+{
+  "root_files": [".watchmanconfig"]
+}

--- a/src/component.jsx
+++ b/src/component.jsx
@@ -2,13 +2,13 @@ import React from 'react'
 import { connect } from 'react-redux'
 import hoistStatics from 'hoist-non-react-statics'
 
+import generatePropTypes from './component/generatePropTypes'
 import loaderContext from './loader_context'
 import processor from './processor'
 import withContext from './node_types/with-context'
 import withProps from './node_types/with-props'
 import withDispatch from './node_types/with-dispatch'
 import { selectCacheKey } from './actions-reducer.js'
-import { map, reduce } from './utils'
 
 const getDisplayName = Component => (
   Component.displayName ||
@@ -175,43 +175,7 @@ export default function fetchTree(options) {
     }
     if (process.env.NODE_ENV !== 'production') {
         LoaderComponent.displayName = `FetchTree(${getDisplayName(Component)})`
-        let group = resourceGroup
-        if (group.TYPE === 'debug') {
-            group = group.child
-        }
-
-        const mergePropShape = (propPaths, node) => {
-            if (node.TYPE === 'virtual' || node.TYPE === 'debug') {
-                return mergePropShape(propPaths, node.child)
-            }
-
-            if (node.TYPE === 'fromProps') {
-                const path = node.path.split('.')
-                const propName = path.shift()
-
-                propPaths[propName] = propPaths[propName] || {}
-                if (path.length > 0) {
-                    path.reduce((current, path) => {
-                        current[path] = current[path] || {}
-                        return current[path]
-                    }, propPaths[propName])
-                }
-            }
-
-            return propPaths
-        }
-        // This produces a tree of objects representing all known props.
-        const propPaths = reduce(group.children, mergePropShape, {})
-
-        LoaderComponent.propTypes = map(propPaths, function makeProptype(tmp) {
-            if (Object.keys(tmp).length === 0) {
-                return React.PropTypes.any.isRequired
-            }
-
-            return React.PropTypes.shape(
-                map(tmp, makeProptype)
-            ).isRequired
-        })
+        LoaderComponent.propTypes = generatePropTypes(resourceGroup)
     }
 
     function mapStateToProps() {

--- a/src/component/generatePropTypes.js
+++ b/src/component/generatePropTypes.js
@@ -1,0 +1,42 @@
+import React from 'react'
+import { map, reduce } from '../utils'
+
+export default function generatePropTypes(resourceGroup) {
+    let group = resourceGroup
+    if (group.TYPE === 'debug') {
+        group = group.child
+    }
+
+    const mergePropShape = (propPaths, node) => {
+        if (node.TYPE === 'virtual' || node.TYPE === 'debug') {
+            return mergePropShape(propPaths, node.child)
+        }
+
+        if (node.TYPE === 'fromProps') {
+            const path = node.path.split('.')
+            const propName = path.shift()
+
+            propPaths[propName] = propPaths[propName] || {}
+            if (path.length > 0) {
+                path.reduce((current, path) => {
+                    current[path] = current[path] || {}
+                    return current[path]
+                }, propPaths[propName])
+            }
+        }
+
+        return propPaths
+    }
+    // This produces a tree of objects representing all known props.
+    const propPaths = reduce(group.children, mergePropShape, {})
+
+    return map(propPaths, function makeProptype(tmp) {
+        if (Object.keys(tmp).length === 0) {
+            return React.PropTypes.any.isRequired
+        }
+
+        return React.PropTypes.shape(
+            map(tmp, makeProptype)
+        ).isRequired
+    })
+}

--- a/src/node_types/debug.js
+++ b/src/node_types/debug.js
@@ -44,4 +44,7 @@ export default register({
             groupEnd('DEBUG')
         }
     },
+    findPropTypes(next, propShape, node) {
+        return next(propShape, node.child)
+    },
 })

--- a/src/node_types/from-props.js
+++ b/src/node_types/from-props.js
@@ -28,4 +28,18 @@ export default register({
             value,
         }
     },
+    findPropTypes(next, propShape, node) {
+        const path = node.path.split('.')
+        const propName = path.shift()
+
+        propShape[propName] = propShape[propName] || {}
+        if (path.length > 0) {
+            path.reduce((current, path) => {
+                current[path] = current[path] || {}
+                return current[path]
+            }, propShape[propName])
+        }
+
+        return propShape
+    },
 })

--- a/src/node_types/group.js
+++ b/src/node_types/group.js
@@ -71,6 +71,9 @@ const group = register({
 
         return results
     },
+    findPropTypes(next, propShape, node) {
+        return reduce(node.children, next, propShape)
+    },
 })
 
 group.debug = function debugGroup(children) {

--- a/src/node_types/virtual.js
+++ b/src/node_types/virtual.js
@@ -22,4 +22,7 @@ export default register({
             excludeProp: true,
         }
     },
+    findPropTypes(next, propShape, node) {
+        return next(propShape, node.child)
+    },
 })

--- a/src/processor.js
+++ b/src/processor.js
@@ -1,4 +1,5 @@
 /* eslint-disable no-console */
+import { registerPropTypeProcessor } from './component/generatePropTypes'
 import { hasMocks, getMock, hasMock } from './mocks'
 const visitors = {}
 
@@ -71,7 +72,7 @@ export default function processor(node, state) {
     }
 }
 
-export const register = ({ TYPE, factory, nodeProcessor }) => {
+export const register = ({ TYPE, factory, nodeProcessor, findPropTypes }) => {
     if (!TYPE) { throw new Error('missing TYPE') }
     if (typeof TYPE !== 'string') { throw new Error('Invalid TYPE (it must be a string)') }
     if (!factory) { throw new Error('missing factory') }
@@ -80,6 +81,8 @@ export const register = ({ TYPE, factory, nodeProcessor }) => {
         throw new Error(`visitor ${TYPE} is already registered`)
     }
     visitors[TYPE] = nodeProcessor
+
+    registerPropTypeProcessor(TYPE, findPropTypes)
 
     // It's useful to attach the nodeProcessor and type for testing purposes.
     factory.nodeProcessor = nodeProcessor

--- a/test-example/tests/__snapshots__/from-props.test.js.snap
+++ b/test-example/tests/__snapshots__/from-props.test.js.snap
@@ -5,7 +5,8 @@ exports[`test use group.debug to log what fetchTree is doing 1`] = `
           \"id\": 1
       },
       \"id\": 1,
-      \"baz\": null
+      \"baz\": null,
+      \"withDefault\": \"default\"
   }
 </pre>
 `;

--- a/test-example/tests/component.test.js
+++ b/test-example/tests/component.test.js
@@ -13,8 +13,11 @@ const Component = fetchTree({
     resourceGroup: group({
         number: fromProps('number'),
         id: fromProps('id'),
+        propWithDefault: fromProps('optional', 'default'),
+
         nestedProp: fromProps('missingData.some.nested.data'),
         otherData: fromProps('missingData.other'),
+        nestedWithDefault: fromProps('nested.withDefault', 'default'),
 
         foo: fromProps('data.foo'),
 

--- a/test-example/tests/from-props.test.js
+++ b/test-example/tests/from-props.test.js
@@ -19,6 +19,7 @@ const ConnectedDummy = fetchTree({
         // Paths can pass through objects that don't exist without errors
         baz: fromProps('params.foo.bar.baz'),
         fakeProp: fromProps('fakeProp'),
+        withDefault: fromProps('withDefault', 'default'),
     }),
 })
 
@@ -37,6 +38,7 @@ test(`use group.debug to log what fetchTree is doing`, async () => {
         id: 1,
         baz: null,
         fakeProp: undefined,
+        withDefault: 'default',
     })
     expect(report.apiRequests).toEqual({})
     expect(report.loadingScreens).toBe(0)


### PR DESCRIPTION
The goal of this PR is to add a 2nd parameter to `fromProps` that provides a default value for that node.

Because the default is for the **node**, this code does not provide a default for `foo`. 

```
        data: fromProps('data', { foo: 'foo' }),
        foo: fromProps('data.foo'),
```